### PR TITLE
Replace favicon with text-based SVG icon

### DIFF
--- a/apps/web/src/app/icon.svg
+++ b/apps/web/src/app/icon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title desc">
+  <title id="title">Plan5 Logo</title>
+  <desc id="desc">Stylized letters P and 5 for the Plan5 application.</desc>
+  <rect width="128" height="128" rx="24" fill="#0f172a" />
+  <g fill="#f8fafc" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-weight="700">
+    <text x="28" y="78" font-size="72">P</text>
+    <text x="70" y="92" font-size="60">5</text>
+  </g>
+</svg>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,0 +1,15 @@
+export const metadata = {
+  title: 'Plan5',
+  description: 'Plan5 Webanwendung',
+  icons: {
+    icon: '/icon.svg',
+  },
+};
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="de">
+      <body>{children}</body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Summary
- replace the binary favicon with a text-based SVG icon for the web app
- update the app layout metadata so the new SVG is used as the icon

## Testing
- npm run lint *(fails: missing package.json in repository)*
- npm run typecheck *(fails: missing package.json in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e37b4addc08321b3a1b02201be23d9