### PR TITLE
docs: add operations guides and edge API contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,61 @@
+# Core Supabase configuration
+SUPABASE_URL="https://<project-ref>.supabase.co" # staging: use staging Supabase project; production: production ref in eu-central-1.
+SUPABASE_SERVICE_ROLE_KEY="service-role-key" # store in secrets manager; never commit real key.
+SUPABASE_EDGE_URL="https://<project-ref>.functions.supabase.co" # base URL for invoking edge functions.
+SUPABASE_EDGE_KEY="edge-invoke-key" # optional: Supabase service role or invoke key for server-to-server calls.
+NEXT_PUBLIC_SUPABASE_EDGE_URL="https://<project-ref>.functions.supabase.co" # exposed to frontend for browser calls.
+NEXT_PUBLIC_SUPPORTED_LOCALES="en-CH,de-CH,fr-CH" # adjust to tenant locales while staying within Swiss language requirements.
+
+# Web application
+NODE_ENV="development"
+REVALIDATE_SECRET="local-revalidate-token" # production: rotate per deployment, store as Vercel/Netlify secret.
+
+# Observability
+SENTRY_DSN="" # production: EU-hosted Sentry DSN; staging can stay empty.
+NEXT_PUBLIC_SENTRY_DSN="" # expose DSN to browser monitoring if required.
+
+# Email providers (choose Resend or Postmark)
+EMAIL_FROM_ADDRESS="notifications@plan5.ch" # staging: use sandbox domain; production: verified sending domain.
+RESEND_API_KEY="" # staging: Resend test key; production: live key with EU data residency enabled.
+POSTMARK_TOKEN="" # optional alternative to Resend. Use Postmark server token (EU region) per environment.
+
+# Payment providers
+STRIPE_SECRET_KEY="sk_test_..." # staging: Stripe test key; production: live restricted key.
+STRIPE_WEBHOOK_SECRET="whsec_test" # configure per environment webhook endpoint.
+CHECKOUT_SUCCESS_URL="https://app.plan5.ch/payments/success" # staging: point to staging domain.
+CHECKOUT_CANCEL_URL="https://app.plan5.ch/payments/cancel" # staging: point to staging domain.
+
+SUMUP_CLIENT_ID="" # SumUp merchant code; staging: sandbox merchant.
+SUMUP_ACCESS_TOKEN="" # OAuth access token; rotate quarterly.
+
+# Email + notifications
+EMAIL_FUNCTION_URL="https://<project-ref>.functions.supabase.co/emails" # staging: use staging edge URL.
+REMINDER_CRON_SECRET="dev-cron-token" # production: random 32+ char secret shared with cron job.
+
+# Billing & invoicing
+BILLING_COMPANY_NAME="Plan5 GmbH"
+BILLING_COMPANY_ADDRESS="Examplestrasse 10"
+BILLING_COMPANY_POSTAL_CODE="8000"
+BILLING_COMPANY_CITY="Zürich"
+BILLING_COMPANY_COUNTRY="CH"
+BILLING_IBAN="CH9300762011623852957" # use production IBAN for live invoices; staging: dummy IBAN.
+
+# Locale & VAT defaults (used in onboarding scripts/seed data)
+DEFAULT_TIMEZONE="Europe/Zurich" # staging/production: align with tenant operating timezone.
+DEFAULT_CURRENCY="CHF" # adjust per tenant if EUR operations are required.
+DEFAULT_VAT_RATE="7.7" # Swiss standard VAT; override if tenant qualifies for reduced rate.
+
+# Supabase edge invocation (optional automation tools)
+SUPABASE_EDGE_FUNCTION_KEY="" # if using dedicated invoke key; differentiate between staging/production keys.
+
+# Email marketing integrations (optional)
+RESEND_REGION="eu" # ensure EU region to maintain data residency.
+POSTMARK_MESSAGE_STREAM="transactional" # staging: sandbox stream.
+
+# Miscellaneous integrations
+SUMUP_WEBHOOK_URL="https://<project-ref>.functions.supabase.co/payments/webhooks/sumup" # document for SumUp console configuration.
+STRIPE_WEBHOOK_URL="https://<project-ref>.functions.supabase.co/payments/webhooks/stripe"
+
+# Feature flags (seeded via config table but listed for completeness)
+ENABLE_SUMUP="true"
+ENABLE_STRIPE="true"

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,34 @@
+# Deployment Guide
+
+## Prerequisites
+- Supabase project hosted in `eu-central-1` (Frankfurt) to satisfy Swiss DSG and EU GDPR data residency.
+- Stripe, SumUp, Resend/Postmark, and Sentry accounts with EU data processing agreements signed.
+- CI/CD pipeline (GitHub Actions, GitLab CI, or Netlify) with environment secrets managed via HashiCorp Vault or Supabase Secrets.
+
+## Environments
+| Environment | Region | Purpose | Notes |
+| --- | --- | --- | --- |
+| `staging` | `eu-central-1` | Pre-production validation, restore testing. | Mirrors production schema; use sandbox payment credentials. |
+| `production` | `eu-central-1` | Customer-facing. | Use live payment credentials and stricter rate limits. |
+
+## Steps
+1. **Prepare environment variables** – Copy `.env.example` to environment-specific secret store. Confirm payment keys align with environment (Stripe live vs test, SumUp live vs sandbox).
+2. **Migrate database** – Run `supabase db push` or apply SQL migrations via CI. Verify migrations succeed in staging before production.
+3. **Deploy edge functions** – `supabase functions deploy --project-ref <ref> --import-map supabase/functions/import_map.json`. Promote after staging smoke tests.
+4. **Deploy web app** – `pnpm install && pnpm build`. Use Next.js incremental static regeneration tokens stored in `REVALIDATE_SECRET`.
+5. **Post-deploy checks** – Execute smoke tests:
+   - `POST /bookings` test booking.
+   - `POST /payments` with Stripe test key.
+   - `POST /compliance` export request.
+   - Trigger reminder cron with staging token.
+6. **Compliance review** – Ensure audit log records deployments (tag commit hash) and update processing records per Swiss regulations.
+
+## Rollback Strategy
+- Web: redeploy previous build from CI artifacts.
+- Edge functions: `supabase functions deploy <name> --import-map ... --version <previous>` using stored release tags.
+- Database: Use Supabase PITR to restore to pre-deployment timestamp in staging, validate, then apply to production if required.
+
+## Regional Considerations
+- Retain logs within EU-based observability platforms; avoid transferring personal data outside EU/CH.
+- Update privacy notice when introducing new processors or sub-processors.
+- Coordinate deployments outside of Swiss federal public holidays when customer support staffing is limited.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,50 @@
 # Plan5
+
+Plan5 is a multi-tenant scheduling and commerce platform for Swiss/EU service businesses. The monorepo combines a Next.js web application, Supabase Postgres, and Supabase Edge Functions to orchestrate bookings, payments, compliance, and operations with Swiss DSG/GDPR alignment.
+
+## Architecture
+- **Next.js app (`apps/web`)** – Customer/staff portal with locale-aware UI (`en-CH`, `de-CH`, `fr-CH`). Uses Supabase Auth, Sentry telemetry, and server actions to trigger edge APIs.
+- **Supabase Edge Functions (`supabase/functions`)** – Domain services for bookings, payments (Stripe + SumUp), emails, invoices, compliance, and scheduled jobs. All HTTP contracts are documented in [`reports/api-contract.yaml`](reports/api-contract.yaml).
+- **Supabase Postgres** – Core data store with row-level security per tenant, audit logging, and support tables for idempotency, compliance, and VAT configuration.
+- **Shared packages (`packages/*`)** – UI components and TypeScript types shared across apps.
+- **Operational docs (`docs/`, `DEPLOYMENT.md`, `RUNBOOK.md`)** – Guidance for EU-central deployments, release management, and incident response.
+
+## Environment Setup
+1. Install dependencies: `corepack enable` then `pnpm install`.
+2. Copy `.env.example` to `.env.local` (for Next.js) and configure Supabase/Stripe/SumUp credentials per environment comments.
+3. Start Supabase locally: `supabase start` (requires Supabase CLI). Ensure project runs in EU-compatible timezone (`Europe/Zurich`).
+4. Seed data if required: `supabase db reset` will apply migrations and seeds.
+5. Run development servers:
+   - Web: `pnpm --filter web dev`
+   - Edge functions: `supabase functions serve --env-file supabase/.env` (set Supabase credentials before running).
+
+## Testing Strategy
+- **Unit/Component tests** – Execute via `pnpm test` (Jest/React Testing Library where available).
+- **Linting/Type checks** – `pnpm lint` and `pnpm typecheck` to ensure consistent code quality.
+- **Edge function dry runs** – `supabase functions serve <name>` with mock payloads. Validate responses align with [`reports/api-contract.yaml`](reports/api-contract.yaml).
+- **Integration flows** – Use the checklists in `docs/booking.md`, `docs/payments.md`, and `docs/operations.md` to verify bookings, payments, reminders, and compliance flows end-to-end.
+- **Observability validation** – Confirm Sentry DSN and Supabase log drains emit telemetry before releases.
+
+## Deployment
+See [`DEPLOYMENT.md`](DEPLOYMENT.md) for the full deployment guide. Key points:
+- Host Supabase in `eu-central-1` to satisfy Swiss DSG/GDPR requirements.
+- Maintain separate staging and production environments with sandbox/live payment credentials.
+- Deploy edge functions via `supabase functions deploy` and the web app via your CI provider (`pnpm build`).
+- Run smoke tests post-deploy: booking creation, payment intent, compliance export, reminder dispatch.
+- Update processing records and privacy notices whenever new processors are introduced.
+
+## API Contract & Documentation
+- Review domain-specific guides under `docs/` (bookings, payments, SumUp integration, roles, ERD, operations).
+- Update [`reports/api-contract.yaml`](reports/api-contract.yaml) whenever edge functions change. Use `npx @redocly/cli lint reports/api-contract.yaml` before opening a PR.
+- Keep compliance/security/disaster recovery practices in sync with `docs/operations.md`, `RUNBOOK.md`, and `RELEASE_CHECKLIST.md`.
+
+## Compliance Alignment
+- Enforce tenant-scoped RBAC and 2FA per `docs/roles.md`.
+- Store data in EU-based services and sign DPAs with all processors (Stripe, SumUp, Resend/Postmark, Sentry).
+- Follow `RUNBOOK.md` for incident handling and `RELEASE_CHECKLIST.md` for approvals to ensure Swiss DSG/GDPR obligations are met.
+
+## Contributing
+1. Branch from `main` and create focused commits.
+2. Update documentation and the OpenAPI contract alongside code changes.
+3. Run the testing commands above.
+4. Submit a PR referencing relevant Jira tickets and include release checklist items.

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,0 +1,39 @@
+# Release Checklist
+
+Use this checklist before promoting a release to production. Attach the completed list to the change request for auditability (Swiss DSG + GDPR).
+
+## Pre-Release
+- [ ] Jira ticket(s) linked with acceptance criteria.
+- [ ] Code reviewed and merged into `main`.
+- [ ] Tests passed locally (`pnpm lint`, `pnpm test`, relevant integration checks).
+- [ ] Database migrations reviewed for backward compatibility and applied to staging.
+- [ ] OpenAPI spec (`reports/api-contract.yaml`) updated and validated with `npx @redocly/cli lint`.
+- [ ] Security review completed for CSP, rate limits, and 2FA impacts.
+
+## Staging Validation
+- [ ] Deploy to staging (Supabase `eu-central-1`).
+- [ ] Execute smoke tests:
+  - [ ] Booking creation and overlap rejection.
+  - [ ] Stripe payment intent with test card.
+  - [ ] SumUp sandbox checkout (if credentials available).
+  - [ ] Compliance export request.
+  - [ ] Reminder cron run with staging secret.
+- [ ] Verify SLO dashboards – booking success ≥ 99%, payment latency within 5 minutes.
+- [ ] Confirm Sentry dashboards show no new untriaged errors.
+
+## Compliance & Communication
+- [ ] Update Records of Processing Activities (RoPA) if new personal data categories introduced.
+- [ ] Notify Data Protection Officer for sign-off if release touches personal data or payment flows.
+- [ ] Draft customer communication (if customer-facing changes) in DE/FR/EN per Swiss requirements.
+
+## Production Release
+- [ ] Schedule deployment outside Swiss public holiday blackout windows.
+- [ ] Confirm on-call rotation aware of release window.
+- [ ] Deploy web + edge functions + migrations.
+- [ ] Run production smoke tests with limited scope (non-destructive bookings/payments).
+- [ ] Announce completion in #ops with release notes and commit hash.
+
+## Post-Release
+- [ ] Monitor alerts for 1 hour (booking latency, payment failures, reminder backlog).
+- [ ] Capture deployment metadata in audit log (`deployment.released` entry with version tag).
+- [ ] Close Jira tickets and update changelog/README if necessary.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,56 @@
+# Operations Runbook
+
+## Scope
+This runbook supports incident responders operating Plan5 in Switzerland/EU, covering outages, degraded performance, or security incidents.
+
+## Incident Classification
+| Severity | Description | Example |
+| --- | --- | --- |
+| SEV-1 | Full outage impacting >50% tenants | Supabase unavailable in `eu-central-1`, booking/payment functions failing. |
+| SEV-2 | Partial outage or regulatory-impacting bug | SumUp webhooks failing, invoices not generating QR-bill. |
+| SEV-3 | Degraded performance or isolated tenant issue | Increased booking latency for one tenant, email bounces. |
+
+## On-Call Checklist
+1. Acknowledge alert in PagerDuty/Opsgenie within 5 minutes.
+2. Announce in `#ops` channel (include severity, impact, lead).
+3. Create incident doc in shared drive (EU-hosted) with timestamp in CET/CEST.
+4. Assign roles: Incident Commander, Communications, Scribe, Liaison to DPO if personal data is impacted.
+
+## Initial Diagnostics
+- Check Supabase status page (Frankfurt region).
+- Review Sentry issues filtered by function (bookings, payments, compliance).
+- Query `supabase logs functions <name> --since "15m"` for request patterns.
+- Validate rate limiting or authentication errors (look for 401/429).
+- For payment incidents, confirm provider status (Stripe, SumUp status pages) and contact merchant support if required.
+
+## Remediation Playbooks
+### Bookings failing with 500/409
+- Inspect `appointments_no_overlap` constraints for stuck transactions.
+- Flush idempotency keys if needed via SQL (`delete from idempotency_keys where expires_at < now();`).
+- If staff availability incorrect, restore from backup or apply manual fix.
+
+### Payments stuck in `pending`
+- Replay Stripe events via dashboard.
+- Trigger `/payments/sumup/status/:checkoutId` for stale SumUp checkouts.
+- For manual settlements, use `/payments/sumup/manual` with staff-provided notes.
+
+### Compliance exports not completing
+- Review `compliance_requests` for `in_progress` > 30 minutes.
+- Check Supabase function logs for `compliance` errors; redeploy if corrupted.
+- Escalate to DPO if deadline risk (<72h to fulfil GDPR/DSG requests).
+
+## Disaster Recovery
+- If data corruption suspected, engage Database SME.
+- Spin up staging project from PITR snapshot and validate.
+- Communicate recovery plan to stakeholders, including estimated RTO (≤4h) and RPO (≤1h).
+
+## Communication Templates
+- **Customer update (DE/FR/EN)** – Provide timeline, impact, mitigation, and regulatory commitment.
+- **Regulatory notice** – If personal data breach, coordinate with DPO to notify FDPIC (Switzerland) and relevant EU authorities within 72 hours.
+
+## Post-Incident
+1. Close incident when service stabilised for 30 minutes.
+2. Conduct blameless post-mortem within 5 working days.
+3. File action items with owners and due dates.
+4. Update this runbook with lessons learned.
+5. Store incident artefacts in EU-hosted archive per retention policy.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,36 @@
+# Edge API Overview
+
+Plan5 exposes Supabase Edge Functions as its public API. All endpoints are documented in [`reports/api-contract.yaml`](../reports/api-contract.yaml) and summarised below. Requests must include a `Bearer` token authorised for the tenant unless stated otherwise.
+
+## Booking & Scheduling
+- `POST /bookings` – Create an appointment. Validates service availability, returns `appointment` record.
+- `POST /calendar` – Retrieve appointments and staff availability for a date range.
+- `POST /reminders` – Cron-protected endpoint to dispatch pending reminders. Requires `REMINDER_CRON_SECRET` token in body.
+
+## Payments & Commerce
+- `POST /payments` – Create Stripe Payment Intent, Stripe Checkout Session, or SumUp checkout depending on payload.
+- `POST /payments/refunds` – Issue provider refund and update Plan5 ledgers.
+- `POST /payments/webhooks/stripe` – Stripe event ingestion.
+- `POST /payments/webhooks/sumup` – SumUp event ingestion.
+- `GET /payments/sumup/status/{checkoutId}` – Poll SumUp checkout status.
+- `POST /payments/sumup/manual` – Manually mark a SumUp checkout as successful.
+- `POST /shop` – Reserve stock for a product and optionally create an order.
+
+## Compliance & Communications
+- `POST /compliance` – Create export or deletion request for data subject.
+- `GET /compliance/status/{id}` – Fetch compliance request state and export URL if available.
+- `POST /compliance/consent` – Record consent granted/revoked events.
+- `POST /emails` – Send transactional email through Resend or Postmark.
+- `POST /emails/webhooks/bounce` – Record email bounce data.
+- `POST /invoices` – Generate invoice, QR-bill payload, and optional notification email.
+
+## Operations
+- `POST /scheduled-stock-release` – Releases expired product reservations; typically triggered by Supabase cron.
+
+## Updating the Contract
+1. Modify edge functions as needed.
+2. Update [`reports/api-contract.yaml`](../reports/api-contract.yaml) to reflect new paths, schemas, or examples.
+3. Run `npx @redocly/cli lint reports/api-contract.yaml` (or equivalent) to validate syntax.
+4. Reference the change in release notes so API consumers know about updates.
+
+> **Note:** Keep payload examples free of personal data. Use anonymised tenant IDs and emails in the specification.

--- a/docs/booking.md
+++ b/docs/booking.md
@@ -1,0 +1,43 @@
+# Booking Domain Guide
+
+## Overview
+Plan5 orchestrates appointment bookings for tenant-specific services. Bookings are persisted in Supabase tables (`appointments`, `services`, `staff_availability`, `reminders`) and augmented by edge functions to enforce business rules and automation.
+
+### Booking Workflow
+1. **Availability lookup** – Clients call the [`/calendar`](./api.md#calendar) edge function to retrieve staff availability and existing appointments in a requested range.
+2. **Slot validation** – When `/bookings` receives a reservation request it revalidates the requested slot against availability windows, overlapping appointments, and service duration/buffer rules.
+3. **Appointment persistence** – Confirmed reservations are written to `appointments` with tenant, service, staff, and customer identifiers. The edge function ensures `appointments_no_overlap` constraints are respected and returns the created record to the caller.
+4. **Reminder scheduling** – For appointments with lead-time larger than the service buffer, the function creates an email reminder job in the `reminders` table.
+5. **Payments and invoicing** – `orders`, `payment_transactions`, and `invoices` associate with appointment IDs so that downstream payment flows can confirm or release reservations.
+
+### Data Relationships
+- `appointments.service_id` → `services.id`
+- `appointments.staff_id` → `profiles.id` (staff)
+- `appointments.customer_id` → `profiles.id` (customer)
+- `reminders.resource_id` references `appointments.id`
+
+### Validation Rules
+- Appointment duration = service duration, `end_at` = `start_at + duration`.
+- Slot must fall within staff availability window for the appointment weekday.
+- No overlap with other `confirmed` appointments for the same staff member.
+- Booking source is tagged via `source` (e.g., `edge:bookings`, `web`), enabling audit trails.
+
+### Operational Tips
+- **Idempotency** – Provide an `Idempotency-Key` header combining customer, slot, or cart identifiers to make retries safe.
+- **Audit logging** – Booking creates audit events accessible from `audit_log` for compliance reporting.
+- **Regional compliance** – Store timestamps in UTC; presentation logic localises to Switzerland-supported locales (`en-CH`, `de-CH`, `fr-CH`). Data residency remains in EU-central deployments of Supabase.
+
+## Common Scenarios
+| Scenario | Guidance |
+| --- | --- |
+| Double-booking detection | 409 status with `Slot unavailable`; prompt user to choose new time. |
+| Outside availability | 422 status with `Outside staff availability`; update staff rota or adjust requested slot. |
+| Reminder opt-out | Remove reminder entries for a customer via `reminders` table or add per-tenant preference flags. |
+| Manual overrides | Staff can update `appointments.status` (`tentative`, `cancelled`) via Supabase UI while preserving audit log history. |
+
+## Testing Checklist
+- Create booking via edge function and confirm `appointments` row.
+- Attempt overlapping booking – expect 409.
+- Create booking outside availability – expect 422.
+- Verify reminder inserted for qualifying appointments.
+- Confirm audit log entry `appointment.booked` emitted with request id.

--- a/docs/erd.md
+++ b/docs/erd.md
@@ -1,0 +1,60 @@
+# Data Model Reference (Textual ERD)
+
+The following outlines primary entities and relationships supporting bookings, payments, and compliance.
+
+## Core Scheduling
+- **tenants** – Root entity for partitioning data.
+- **profiles** – User profiles (customers, staff) with tenant scope.
+- **services** – Configurable offerings per tenant including duration, buffers, price.
+- **staff_availability** – Weekly availability slots per staff member.
+- **appointments** – Reservations linking tenants, services, staff, and customers.
+- **reminders** – Outbound reminder jobs referencing appointments or other resources.
+
+Relationships:
+- `profiles.tenant_id` → `tenants.id`
+- `services.tenant_id` → `tenants.id`
+- `appointments.service_id` → `services.id`
+- `appointments.staff_id` → `profiles.id`
+- `appointments.customer_id` → `profiles.id`
+- `reminders.resource_id` → `appointments.id`
+
+## Commerce & Billing
+- **orders** – Monetary commitments associated with bookings or product reservations.
+- **order_items** – Line items per order.
+- **payment_transactions** – Provider-specific transactions (Stripe, SumUp) tied to orders.
+- **payment_refunds** – Refund history referencing payment transactions.
+- **sumup_sessions** – Temporary storage of SumUp checkout state.
+- **invoices** – Issued invoices including Swiss QR-bill payload.
+- **invoice_items** – Invoice line items referencing invoices.
+- **invoice_archives** – Hash + storage reference for immutable invoice snapshots.
+- **vat_settings** – Effective VAT rates per tenant.
+
+Relationships:
+- `orders.tenant_id` → `tenants.id`
+- `order_items.order_id` → `orders.id`
+- `payment_transactions.order_id` → `orders.id`
+- `payment_refunds.transaction_id` → `payment_transactions.id`
+- `sumup_sessions.order_id` → `orders.id`
+- `invoices.order_id` → `orders.id`
+- `invoice_items.invoice_id` → `invoices.id`
+- `invoice_archives.invoice_id` → `invoices.id`
+
+## Compliance & Audit
+- **audit_log** – Canonical log of privileged actions.
+- **compliance_requests** – GDPR/Swiss DSG export or deletion workflows.
+- **consents** – Records of consent grants/revocations.
+- **email_bounces** – Tracking of bounced transactional emails.
+- **idempotency_keys** – Stored responses to deduplicate requests.
+
+Relationships:
+- `audit_log.tenant_id` → `tenants.id`
+- `compliance_requests.tenant_id` → `tenants.id`
+- `consents.tenant_id` → `tenants.id`
+- `email_bounces.tenant_id` → `tenants.id`
+- `idempotency_keys.tenant_id` → `tenants.id`
+
+## Diagram Tips
+To visualise the schema:
+1. Run `supabase db inspect --schema app_public > schema.dot`.
+2. Convert to SVG using Graphviz (`dot -Tsvg schema.dot -o docs/schema.svg`).
+3. Store diagrams under `docs/` while keeping personal data out of examples.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,56 @@
+# Operations Handbook
+
+## Change Management
+- Track changes via GitHub PRs with mandatory reviews for payments, compliance, or schema migrations.
+- Use feature flags within Supabase config tables for gradual rollouts.
+- Maintain a change calendar for customer-facing features to avoid Swiss public holidays impacting hospitality/clinic operations.
+
+## Security Controls
+### Content Security Policy (CSP)
+- Frontend served via Next.js must emit a strict CSP covering scripts (`'self'`, `https://*.supabase.co`, `https://js.stripe.com`) and frames for Stripe Checkout or SumUp. Maintain a report-only endpoint for new third-party inclusions.
+- Enforce HTTPS with HSTS (31536000 seconds) and `includeSubDomains` for `.plan5.ch`.
+
+### Rate Limiting
+- Edge functions rely on Supabase network-level quotas. Augment with the `idempotency_keys` table to detect replayed requests.
+- Use API gateway (e.g., Cloudflare) to enforce per-tenant rate limits: 60 bookings/min, 30 payments/min, 10 compliance exports/day.
+- Log rate-limit breaches to Sentry tagged with `tenantId` for follow-up.
+
+### Two-Factor Authentication (2FA)
+- Require 2FA for staff/admin accounts through Supabase Auth or federated IdP (Azure AD/Keycloak) configured for Swiss tenants.
+- Store 2FA recovery codes in tenant-managed password managers. Audit completion quarterly to satisfy FINMA guidance for financial-like systems.
+
+## Disaster Recovery
+- **Backups** – Enable Supabase PITR (point-in-time recovery) and schedule daily logical dumps stored in EU (Frankfurt) object storage.
+- **Testing** – Perform quarterly restore tests into a staging project. Validate bookings, payments, and invoices can be replayed without violating idempotency safeguards.
+- **Runbooks** – See [`RUNBOOK.md`](../RUNBOOK.md) for outage handling and communication templates compliant with Swiss DSG reporting timelines.
+- **RPO/RTO** – Target RPO ≤ 1 hour, RTO ≤ 4 hours. Document exceptions in post-incident reports.
+
+## Observability
+### Service Level Objectives (SLO)
+- **Booking success rate** – 99.5% of `POST /bookings` requests succeed over 30 days.
+- **Payment completion** – 99% of payments reach `paid` or `pending` status within 5 minutes.
+- **Reminder dispatch latency** – 95% of reminders processed within 2 minutes of scheduled time.
+
+### Service Level Indicators (SLI)
+- Instrument edge functions with latency histograms via Supabase logs exported to your observability stack (Datadog, Grafana Loki).
+- Record error rates from Sentry issues tagged by function name.
+- Track queue depth of `reminders` to detect backlog.
+
+### Alerting
+- Integrate Supabase log drains with PagerDuty or Opsgenie.
+- Configure alerts for:
+  - Payment webhook failure rate >5% over 15 minutes.
+  - Reminder backlog >50 pending items.
+  - Booking latency p95 > 2s.
+- Align alert severities with Swiss business hours; use follow-the-sun coverage for EU operations.
+
+## Regional Compliance Guidance
+- Host Supabase in `eu-central-1` (Frankfurt) to meet Swiss/EU data residency.
+- Sign DPAs with Stripe, SumUp, Resend/Postmark, and Resend sub-processors. Store evidence in Confluence/SharePoint.
+- Maintain Swiss DSG and GDPR records of processing, including appointment data retention policies.
+- Implement customer data deletion workflows within 30 days of request, with evidence stored for audits.
+
+## Operational Contacts
+- **Incident Commander** – On-call engineer (rotating weekly) responsible for cross-team coordination.
+- **Data Protection Officer** – Ensures compliance with Swiss DSG & GDPR reporting obligations.
+- **Finance Lead** – Approves refunds > CHF 500 and SumUp manual settlements.

--- a/docs/payments.md
+++ b/docs/payments.md
@@ -1,0 +1,42 @@
+# Payments Playbook
+
+## Supported Providers
+Plan5 supports Stripe and SumUp for card-present and online payments. Both are orchestrated through the `/payments` edge function with per-tenant audit logging.
+
+### Stripe
+- **Intent mode** – Default. Creates a Payment Intent with automatic payment methods and optional appointment metadata.
+- **Checkout Session mode** – Use `mode: "checkout_session"` to redirect customers to Stripe Checkout with automatic tax.
+- **Webhooks** – `/payments/webhooks/stripe` processes `payment_intent.*` and `checkout.session.completed` events. Idempotency is enforced through `payment_webhook_events`.
+- **Refunds** – `/payments/refunds` triggers `payment_transactions` updates and `payment_refunds` entries.
+
+### SumUp
+- **Online checkout** – `/payments` with `provider: "sumup"` creates a SumUp checkout and stores session metadata in `sumup_sessions`.
+- **Manual settlement** – `/payments/sumup/manual` records card-present transactions that were processed outside the API but require ledger alignment.
+- **Status polling** – `/payments/sumup/status/:checkoutId` fetches the latest state from SumUp and updates the session record.
+- **Webhooks** – `/payments/webhooks/sumup` listens for asynchronous status updates and reconciles orders.
+
+## Data Model
+| Table | Purpose |
+| --- | --- |
+| `payment_transactions` | Stores provider transaction identifiers, amounts, currency, and status. |
+| `orders` | Booking or shop orders tied to payment lifecycle. |
+| `payment_refunds` | Refund history including initiator and provider IDs. |
+| `payment_webhook_events` | Deduplication of provider webhooks. |
+| `sumup_sessions` | Tracks SumUp checkout sessions, deeplinks, and polling metadata. |
+
+## Operational Considerations
+- **Idempotency** – Provide `Idempotency-Key` header; defaults use `orderId`-derived keys.
+- **Currency** – Accepts ISO 4217 codes. Stripe API lowercases; SumUp uppercases. Validate per-tenant allowed currencies (CHF/EUR) to stay compliant with Swiss VAT reporting.
+- **Audit** – All payment flows record events such as `payment.intent.created`, `payment.refund.created`, or `payment.sumup.completed` for traceability.
+- **3-D Secure** – Stripe requests 3DS automatically; ensure customer UI handles `nextAction` instructions returned by the API.
+- **Compliance** – Store only provider IDs and minimal metadata to remain PCI SAQ A. Card data never touches Plan5 infrastructure.
+
+## Monitoring & Alerts
+- Configure alerts on `payment_transactions.status` transitions (`failed`, `requires_payment_method`).
+- Ingest provider webhook failures into Sentry via `_shared/captureException`.
+- Track refund volume vs sales in Supabase dashboards for finance sign-off.
+
+## Recovery Steps
+- If Stripe webhook delivery fails, replay events via Stripe dashboard filtered by signing secret.
+- For SumUp, re-poll `/payments/sumup/status/:checkoutId` and reconcile with merchant portal exports.
+- Use `recordAudit` trails when investigating disputed transactions.

--- a/docs/roles.md
+++ b/docs/roles.md
@@ -1,0 +1,28 @@
+# Access Roles & Responsibilities
+
+Plan5 enforces tenant-scoped RBAC with three primary roles exposed through Supabase JWT claims. Understanding responsibilities per role is critical for enforcing Swiss data-protection regulations.
+
+## Role Matrix
+| Role | Description | Typical Actors | Capabilities |
+| --- | --- | --- | --- |
+| `customer` | End customers booking services. | Public users. | Create bookings, view their appointments, receive reminders. No access to staff data beyond own bookings. |
+| `staff` | Staff members fulfilling services. | Therapists, consultants. | Manage personal availability, confirm or cancel their assigned appointments, view customer contact data relevant to assigned bookings. |
+| `admin` | Tenant administrators. | Clinic managers, franchise owners. | Configure services, manage staff accounts, view financial reports, trigger compliance exports/deletions, manage invoices and payments. |
+
+## Security Expectations
+- **Least privilege** – Ensure JWT claims embed `tenant_id` to scope database policies. Review PostgREST policies to avoid cross-tenant leakage.
+- **2FA requirement** – Staff and admin logins must enforce 2FA via Supabase Auth or external identity provider. Document recovery codes and rotation procedures per tenant.
+- **Audit logging** – All admin actions feed into `audit_log`. Review logs quarterly to meet GDPR accountability obligations.
+- **Data minimisation** – Customers should only see their appointments; staff should only handle data necessary for service delivery.
+
+## Onboarding Checklist
+1. Invite user via Supabase Auth with tenant metadata.
+2. Assign role in JWT or via Postgres function on signup.
+3. Capture acceptance of data processing agreement for admins.
+4. Enable 2FA and store backup codes in encrypted vault.
+
+## Offboarding Checklist
+- Revoke Supabase Auth session and delete refresh tokens.
+- Rotate shared secrets (SumUp access tokens, Stripe restricted keys) if admins depart.
+- Transfer ownership of scheduled reports to another admin.
+- Confirm compliance exports or deletions are completed for leaving staff per Swiss labour law retention policies.

--- a/docs/sumup.md
+++ b/docs/sumup.md
@@ -1,0 +1,32 @@
+# SumUp Integration Guide
+
+## Credentials & Configuration
+- **SUMUP_CLIENT_ID** – Merchant code issued by SumUp. In production, create via SumUp Business API. For staging, request a sandbox merchant account and flag credentials as non-live.
+- **SUMUP_ACCESS_TOKEN** – OAuth access token with `payments` scope. Rotate quarterly and store in a secrets manager. For staging, use a token bound to the sandbox merchant.
+- **Allowed Origins** – Configure the SumUp dashboard to accept the Plan5 domain for deep links (e.g., `https://app.plan5.ch`).
+
+## Flow Summary
+1. **Checkout creation** – `/payments` with `provider: "sumup"` issues a `POST /v0.1/checkouts` call to SumUp. Response includes `checkout_url` for app/web handoff.
+2. **Session persistence** – Checkout metadata is stored in `sumup_sessions` for reconciliation and later manual overrides.
+3. **Customer handoff** – Use the returned deeplink to open the SumUp app (card-present) or hosted page (card-not-present).
+4. **Status polling** – `/payments/sumup/status/:checkoutId` polls SumUp and updates the session row.
+5. **Webhook handling** – `/payments/webhooks/sumup` ingests asynchronous status updates and marks orders as paid/failed.
+6. **Manual settlements** – `/payments/sumup/manual` marks transactions as `succeeded` when a terminal payment was captured offline.
+
+## Compliance Notes
+- **PSD2 & SCA** – SumUp handles strong customer authentication; Plan5 only stores transaction references, keeping us out of PCI scope beyond SAQ A.
+- **Swiss regulations** – For CHF payments, ensure the merchant account is domiciled in Switzerland. VAT documentation is produced via `invoices` with Swiss QR-bill support.
+- **Data residency** – SumUp API is EU-hosted; ensure data processing agreements (DPAs) are signed and referenced in the tenant onboarding documentation.
+
+## Monitoring
+- Track SumUp webhook delivery failures in Supabase `payment_webhook_events`.
+- Alert when `sumup_sessions.status` remains `pending` for >15 minutes.
+- Reconcile daily with SumUp exports to verify captured amounts vs `payment_transactions`.
+
+## Troubleshooting
+| Issue | Steps |
+| --- | --- |
+| Checkout URL expired | Call status endpoint; if expired, create a new checkout with identical parameters. |
+| SumUp app fails to open | Confirm deeplink is whitelisted and user device has SumUp app installed. Provide fallback to web checkout. |
+| Webhook signature validation | SumUp webhooks currently unauthenticated; ensure endpoint is hidden behind Supabase function secrets and store event IDs to dedupe. |
+| Currency mismatch | Verify request currency matches merchant account supported currency (CHF/EUR). |

--- a/reports/api-contract.yaml
+++ b/reports/api-contract.yaml
@@ -1,0 +1,738 @@
+openapi: 3.1.0
+info:
+  title: Plan5 Edge API
+  version: 1.0.0
+  description: |
+    HTTP contract for Plan5 Supabase Edge Functions covering bookings, payments,
+    compliance, email, and operational automation. All endpoints require a
+    tenant-scoped Bearer token unless noted. Examples use anonymised identifiers
+    to stay within Swiss/EU data protection guidelines.
+servers:
+  - url: https://<project-ref>.functions.supabase.co
+    description: Supabase Edge runtime (replace `<project-ref>` per environment)
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    BookingRequest:
+      type: object
+      required: [tenantId, serviceId, staffId, customerId, startAt]
+      properties:
+        tenantId:
+          type: string
+          format: uuid
+        serviceId:
+          type: string
+          format: uuid
+        staffId:
+          type: string
+          format: uuid
+        customerId:
+          type: string
+          format: uuid
+        startAt:
+          type: string
+          format: date-time
+        notes:
+          type: string
+        source:
+          type: string
+    BookingResponse:
+      type: object
+      properties:
+        appointment:
+          type: object
+          description: Created appointment record from Supabase.
+    CalendarRequest:
+      type: object
+      required: [tenantId]
+      properties:
+        tenantId:
+          type: string
+          format: uuid
+        staffId:
+          type: string
+          format: uuid
+        rangeStart:
+          type: string
+          format: date-time
+        rangeEnd:
+          type: string
+          format: date-time
+    CalendarResponse:
+      type: object
+      properties:
+        appointments:
+          type: array
+          items:
+            type: object
+        availability:
+          type: array
+          items:
+            type: object
+    PaymentIntentRequest:
+      type: object
+      required: [tenantId, orderId, amountCents, currency, customerEmail]
+      properties:
+        tenantId:
+          type: string
+          format: uuid
+        orderId:
+          type: string
+          format: uuid
+        amountCents:
+          type: integer
+          minimum: 1
+        currency:
+          type: string
+          minLength: 3
+          maxLength: 3
+        customerEmail:
+          type: string
+          format: email
+        customerName:
+          type: string
+        locale:
+          type: string
+        mode:
+          type: string
+          enum: [payment_intent, checkout_session]
+        provider:
+          type: string
+          enum: [stripe, sumup]
+        appointmentId:
+          type: string
+          format: uuid
+        metadata:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: string
+              - type: number
+              - type: boolean
+    PaymentIntentResponse:
+      type: object
+      properties:
+        provider:
+          type: string
+        clientSecret:
+          type: string
+        checkoutUrl:
+          type: string
+          format: uri
+        intentId:
+          type: string
+        status:
+          type: string
+        amountCents:
+          type: integer
+        currency:
+          type: string
+        nextAction:
+          type: object
+          properties:
+            type:
+              type: string
+            url:
+              type: string
+              format: uri
+    RefundRequest:
+      type: object
+      required: [tenantId, orderId, transactionId, initiatedBy]
+      properties:
+        tenantId:
+          type: string
+          format: uuid
+        orderId:
+          type: string
+          format: uuid
+        transactionId:
+          type: string
+          format: uuid
+        amountCents:
+          type: integer
+        reason:
+          type: string
+        initiatedBy:
+          type: string
+          enum: [customer, staff, system]
+    RefundResponse:
+      type: object
+      properties:
+        refundId:
+          type: string
+        status:
+          type: string
+        amountCents:
+          type: integer
+        currency:
+          type: string
+        provider:
+          type: string
+    SumUpManualRequest:
+      type: object
+      required: [tenantId, orderId, checkoutId]
+      properties:
+        tenantId:
+          type: string
+          format: uuid
+        orderId:
+          type: string
+          format: uuid
+        checkoutId:
+          type: string
+        staffId:
+          type: string
+          format: uuid
+        notes:
+          type: string
+    ComplianceRequest:
+      type: object
+      required: [tenantId, subjectId, type]
+      properties:
+        tenantId:
+          type: string
+          format: uuid
+        subjectId:
+          type: string
+          format: uuid
+        type:
+          type: string
+          enum: [export, delete]
+        initiatedBy:
+          type: string
+          enum: [customer, staff, system]
+        reason:
+          type: string
+    ComplianceResponse:
+      type: object
+      properties:
+        requestId:
+          type: string
+        status:
+          type: string
+        exportUrl:
+          type: string
+    ConsentRequest:
+      type: object
+      required: [tenantId, subjectId, consentType, granted]
+      properties:
+        tenantId:
+          type: string
+          format: uuid
+        subjectId:
+          type: string
+          format: uuid
+        consentType:
+          type: string
+        granted:
+          type: boolean
+        metadata:
+          type: object
+    EmailRequest:
+      type: object
+      required: [to, template]
+      properties:
+        tenantId:
+          type: string
+          format: uuid
+        to:
+          type: string
+          format: email
+        cc:
+          type: array
+          items:
+            type: string
+            format: email
+        bcc:
+          type: array
+          items:
+            type: string
+            format: email
+        template:
+          type: string
+          enum:
+            - booking_confirmation
+            - payment_receipt
+            - invoice_ready
+            - reminder_upcoming
+            - gdpr_export_ready
+            - gdpr_deletion_confirmed
+            - custom
+        locale:
+          type: string
+        subject:
+          type: string
+        data:
+          type: object
+        attachments:
+          type: array
+          items:
+            type: object
+            properties:
+              filename:
+                type: string
+              content:
+                type: string
+              type:
+                type: string
+        ics:
+          type: array
+          items:
+            type: object
+            required: [uid, start, end, summary]
+            properties:
+              uid:
+                type: string
+              start:
+                type: string
+                format: date-time
+              end:
+                type: string
+                format: date-time
+              summary:
+                type: string
+              description:
+                type: string
+              location:
+                type: string
+        providerHint:
+          type: string
+          enum: [resend, postmark]
+    InvoiceRequest:
+      type: object
+      required: [tenantId, orderId]
+      properties:
+        tenantId:
+          type: string
+          format: uuid
+        orderId:
+          type: string
+          format: uuid
+        locale:
+          type: string
+        dueDate:
+          type: string
+          format: date-time
+        sendEmail:
+          type: boolean
+        emailOverride:
+          type: string
+          format: email
+    ReminderProcessRequest:
+      type: object
+      required: [token]
+      properties:
+        token:
+          type: string
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 100
+    ShopRequest:
+      type: object
+      required: [tenantId, productId, quantity, customerId]
+      properties:
+        tenantId:
+          type: string
+          format: uuid
+        productId:
+          type: string
+          format: uuid
+        quantity:
+          type: integer
+          minimum: 1
+        customerId:
+          type: string
+          format: uuid
+        orderId:
+          type: string
+          format: uuid
+paths:
+  /bookings:
+    post:
+      summary: Create an appointment.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BookingRequest'
+      responses:
+        '200':
+          description: Booking created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BookingResponse'
+        '400':
+          description: Validation error.
+  /calendar:
+    post:
+      summary: Retrieve appointments and availability for a range.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CalendarRequest'
+      responses:
+        '200':
+          description: Calendar data.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarResponse'
+        '400':
+          description: Invalid payload.
+  /payments:
+    post:
+      summary: Create Stripe or SumUp payment intent/checkout.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PaymentIntentRequest'
+      responses:
+        '200':
+          description: Payment intent details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaymentIntentResponse'
+        '400':
+          description: Unable to create payment.
+  /payments/refunds:
+    post:
+      summary: Issue a refund through the underlying provider.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RefundRequest'
+      responses:
+        '200':
+          description: Refund accepted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RefundResponse'
+        '400':
+          description: Refund rejected.
+  /payments/webhooks/stripe:
+    post:
+      summary: Stripe webhook receiver.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: Stripe event payload (see Stripe API).
+      responses:
+        '200':
+          description: Event accepted.
+        '400':
+          description: Invalid signature or payload.
+  /payments/webhooks/sumup:
+    post:
+      summary: SumUp webhook receiver.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: SumUp webhook payload.
+      responses:
+        '200':
+          description: Event processed.
+  /payments/sumup/status/{checkoutId}:
+    get:
+      summary: Poll SumUp checkout status.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: checkoutId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Checkout status payload.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  checkoutId:
+                    type: string
+                  status:
+                    type: string
+                  amountCents:
+                    type: integer
+                  currency:
+                    type: string
+                  lastPolledAt:
+                    type: string
+                    format: date-time
+                  deeplink:
+                    type: string
+                    format: uri
+        '400':
+          description: Invalid checkout id.
+  /payments/sumup/manual:
+    post:
+      summary: Record manual SumUp settlement.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SumUpManualRequest'
+      responses:
+        '200':
+          description: Manual settlement recorded.
+        '400':
+          description: Invalid request.
+  /shop:
+    post:
+      summary: Reserve product stock and ensure order.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ShopRequest'
+      responses:
+        '200':
+          description: Reservation result.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  orderId:
+                    type: string
+                  stock:
+                    type: object
+        '400':
+          description: Failed reservation.
+  /compliance:
+    post:
+      summary: Create compliance export or delete request.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ComplianceRequest'
+      responses:
+        '200':
+          description: Compliance request accepted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComplianceResponse'
+        '400':
+          description: Invalid payload.
+  /compliance/consent:
+    post:
+      summary: Record consent grant or revocation.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConsentRequest'
+      responses:
+        '200':
+          description: Consent recorded.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+        '400':
+          description: Invalid request.
+  /compliance/status/{id}:
+    get:
+      summary: Retrieve compliance request status.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Compliance status payload.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComplianceResponse'
+        '404':
+          description: Request not found.
+  /emails:
+    post:
+      summary: Send transactional email.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmailRequest'
+      responses:
+        '200':
+          description: Email accepted by provider.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  provider:
+                    type: string
+                  guidance:
+                    type: string
+        '400':
+          description: Invalid payload.
+  /emails/webhooks/bounce:
+    post:
+      summary: Receive bounce notifications.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [provider, email]
+              properties:
+                provider:
+                  type: string
+                  enum: [resend, postmark]
+                email:
+                  type: string
+                  format: email
+                reason:
+                  type: string
+                occurredAt:
+                  type: string
+                  format: date-time
+                tenantId:
+                  type: string
+                  format: uuid
+      responses:
+        '200':
+          description: Bounce recorded.
+        '400':
+          description: Invalid payload.
+  /invoices:
+    post:
+      summary: Generate invoice and optional email.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InvoiceRequest'
+      responses:
+        '200':
+          description: Invoice generated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  invoiceId:
+                    type: string
+                  invoiceNumber:
+                    type: string
+                  issuedAt:
+                    type: string
+                    format: date-time
+                  dueDate:
+                    type: string
+                    format: date-time
+                  totalCents:
+                    type: integer
+                  currency:
+                    type: string
+                  qrBillPayload:
+                    type: string
+        '400':
+          description: Invoice generation failed.
+  /reminders:
+    post:
+      summary: Dispatch scheduled reminders.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReminderProcessRequest'
+      responses:
+        '200':
+          description: Reminder batch processed.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+        '401':
+          description: Invalid token.
+  /scheduled-stock-release:
+    post:
+      summary: Release expired stock reservations.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Number of stock reservations released.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  released:
+                    type: integer
+        '500':
+          description: Unexpected error.


### PR DESCRIPTION
## Summary
- add new domain documentation for bookings, payments, SumUp, roles, API usage, ERD, and operations
- provide environment template plus deployment, release, and incident runbooks with CH/EU compliance guidance
- publish OpenAPI contract for edge functions and expand the README with architecture, setup, testing, and deployment notes

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e38b8bf6fc832183e6ca8e922f4c75